### PR TITLE
refactor(scenario-map): Connect ScenarioMap directly to redux store.

### DIFF
--- a/lib/map/scenario-map.js
+++ b/lib/map/scenario-map.js
@@ -1,6 +1,9 @@
 /** A map component showing a scenario */
 
 import React, { Component, PropTypes } from 'react'
+import {connect} from 'react-redux'
+import {setMapState} from '../actions'
+
 import { Map as LeafletMap, TileLayer, FeatureGroup } from 'react-leaflet'
 import AddTripPatternLayer from './add-trip-pattern-layer'
 import StopSelectPolygon from './stop-select-polygon'
@@ -19,7 +22,18 @@ import colors from '../colors'
 // with this on we might be able to get rid of the stop layer
 window.L_PREFER_CANVAS = true
 
-export default class ScenarioMap extends Component {
+function mapStateToProps (state) {
+  return {
+    activeModification: state.scenario.activeModification,
+    data: state.scenario.data,
+    mapState: state.mapState,
+    modifications: state.scenario.modifications
+  }
+}
+
+const mapDispatchToProps = {setMapState}
+
+class ScenarioMap extends Component {
   static propTypes = {
     activeModification: PropTypes.object,
     bundle: PropTypes.shape({
@@ -196,3 +210,5 @@ export default class ScenarioMap extends Component {
     }
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(ScenarioMap)

--- a/lib/scenario-editor.js
+++ b/lib/scenario-editor.js
@@ -19,7 +19,6 @@ import authenticatedFetch, {parseJSON} from './utils/authenticated-fetch'
 
 function mapStateToProps (state) {
   return {
-    activeModification: state.scenario.activeModification,
     bundleId: state.scenario.bundleId,
     data: state.scenario.data,
     id: state.scenario.id,
@@ -102,7 +101,7 @@ class ScenarioEditor extends Component {
   }
 
   render () {
-    const {activeModification, bundleId, createVariant, data, login, logout, mapState, modifications, name, push, setMapState, updateVariant, user} = this.props
+    const {bundleId, data, login, logout, name, push, user} = this.props
     const bundle = data.bundles.find((b) => b.id === bundleId)
     const bundleName = bundle && bundle.name
     return (
@@ -117,15 +116,8 @@ class ScenarioEditor extends Component {
           }}
           >
           <ScenarioMap
-            activeModification={activeModification}
             bundle={bundle}
-            createVariant={createVariant}
-            data={data}
-            mapState={mapState}
-            modifications={modifications}
             replaceModification={this.getDataAndReplaceModification}
-            setMapState={setMapState}
-            updateVariant={updateVariant}
             />
         </div>
 


### PR DESCRIPTION
Use react-redux's `connect` function to make `ScenarioMap` a "smart" component. Reduces coupling
between `ScenarioEditor` and `ScenarioMap`. Work in progress towards issue #122.

I didn't have any "real" data to test the changes with, but I did what I could put together some fake data to use for testing by examining your graphql query and `project-store`.

I tried to match your style and conventions as closely as I could, but if there are any issues I'd be happy to correct them.

(You might be wondering why a random person is sending in a PR - I came across Conveyal in a job listing for a javascript engineer position, and since your team has a bunch of code on github I thought I'd dig through it a little bit and get a feel for some of the projects you're working on. Interesting stuff!)