### PR TITLE
docs(README): Update mastarm usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ To use `Auth0`, copy the `/configurations/default/env.yml.tmp` to `/configuratio
 
 ```bash
 $ npm install -g mastarm
-$ mastarm serve lib/index.js --proxy http://localhost:7070/api
+$ mastarm build --serve lib/index.js --proxy http://localhost:7070/api
 ```


### PR DESCRIPTION
Update "how to run" instructions to use the `build --serve` command with mastarm.

This is how I was able to get scenario-editor to build/run anyway. I might just be using mastarm incorrectly...?  Came across this while working in #126. 