### PR TITLE
Exact times

### DIFF
--- a/docs/edit-scenario.md
+++ b/docs/edit-scenario.md
@@ -10,13 +10,13 @@ After uploading a bundle and creating a project, you will arrive at a screen tha
 
 A transport scenario is made up of many modifications, each of which represents a single operation on the transit network (for example adding a line, or adjusting
 the speed of an existing line). All modifications are listed in the left-hand bar. Each modification has an eye icon next to it, which controls whether it is currently
-displayed on the map. Clicking on the title of a modification will open it and allow you to edit it. To create a new modification of a particular type, 
+displayed on the map. Clicking on the title of a modification will open it and allow you to edit it. To create a new modification of a particular type,
 
 Oftentimes, there will be several scenarios that are very similar, differing only in a few minor aspects. In particular, one scenario is often
 a superset of another (for instance, there is a base scenario which involves building six new rail lines, and another scenario which additionally
 involves building four more). Instead of having to code each scenario separately, we support the concept of scenario variants. You can create variants
 by clicking the "Create" button under "Variants," and entering a name for each variant. The buttons to the right of a variant name allow, respectively, exporting the
-variant to Transport Analyst, viewing a printer-friendly summary of the modifications in the variant, and showing the variant on the map.	
+variant to Transport Analyst, viewing a printer-friendly summary of the modifications in the variant, and showing the variant on the map.
 
 <img src="../img/variant-editor.png" />
 
@@ -76,6 +76,22 @@ the alignment editor before doing this.) You will see this view:
 Here you can specify the days of service, span of service, frequency, speed and dwell time. You can add as many timetables as you need to specify different frequencies or speeds at
 different times of days.
 
+You can additionally choose whether the frequency entry represents an assumed headway, or represents the
+exact schedule, using the "Times are exact" checkbox. For example, consider an entry specifying that
+a particular pattern runs every 15 minutes from 9 AM until 7 PM. If the checkbox is left unchecked,
+the software will assume that vehicles depart the first stop on the route every 15 minutes between
+9 AM and 7 PM, but with no assumptions as to exactly when that will happen. For example, vehicles might
+leave at 9:02, 9:17, 9:32, and so on, or they might leave at 9:10, 9:25, 9:40, etc.; many of these possibilities
+will be tested and averaged in order to get a complete picture of how different possible schedules
+might perform. This option should be chosen when a frequency is known but a schedule has not yet been
+written for a future system.
+
+In the rare case in which the complete schedule is known at the time of scenario creation, the "Times are exact"
+checkbox can be activated. In this case, a single schedule will be created, with the first departure
+at the start time, and then additional departures with exactly the specified frequency until (but not
+including) the end time. For example, in the scenario given above, the vehicles would be scheduled
+to depart at exactly 9:00, 9:15, 9:30 until 6:45 (not at 7:00 because the end time is not included).
+
 You can delete this or any modification using the red "Delete Modification" button.
 
 ## Remove trips
@@ -132,6 +148,22 @@ for all the service you want to retain, in both directions. The software will le
 will operate at the specified frequencies (e.g., if you have a ten-minute frequency and a 15-minute frequency overlapping, there will be one set of vehicles coming every ten minutes,
 and another, independent, set coming every 15).
 
+You can additionally choose whether the frequency entry represents an assumed headway, or represents the
+exact schedule, using the "Times are exact" checkbox. For example, consider an entry specifying that
+a particular pattern runs every 15 minutes from 9 AM until 7 PM. If the checkbox is left unchecked,
+the software will assume that vehicles depart the first stop on the route every 15 minutes between
+9 AM and 7 PM, but with no assumptions as to exactly when that will happen. For example, vehicles might
+leave at 9:02, 9:17, 9:32, and so on, or they might leave at 9:10, 9:25, 9:40, etc.; many of these possibilities
+will be tested and averaged in order to get a complete picture of how different possible schedules
+might perform. This option should be chosen when a frequency is known but a schedule has not yet been
+written for a future system.
+
+In the rare case in which the complete schedule is known at the time of scenario creation, the "Times are exact"
+checkbox can be activated. In this case, a single schedule will be created, with the first departure
+at the start time, and then additional departures with exactly the specified frequency until (but not
+including) the end time. For example, in the scenario given above, the vehicles would be scheduled
+to depart at exactly 9:00, 9:15, 9:30 until 6:45 (not at 7:00 because the end time is not included).
+
 You can choose to remove all existing trips on the route (the default) or choose to retain trips outside the time windows in which you specify frequencies, which is useful
 when you are changing the frequency for only part of the day (e.g. increased weekend frequency) and want to retain the existing scheduled service at other times. This is controlled using the "Retain existing scheduled trips at times without new frequencies specified" checkbox.
 
@@ -151,5 +183,3 @@ after that point will be rerouted. This can be used to extend routes, or to dive
 You can then edit the alignment and the intermediate stops by clicking on "Edit Alignment." This uses the same tools that are used when adding trip patterns.
 
 This modification is displayed on the map with the route being modified in gray, any segments that are being replaced in red, and the new segments in blue.
-
-

--- a/lib/components/modification/__tests__/__snapshots__/add-trip-pattern.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/add-trip-pattern.js.snap
@@ -232,6 +232,17 @@ exports[`Component > Modification > AddTripPattern renders correctly 1`] = `
               type="time"
               value="16:00" />
           </div>
+          <div
+            className="checkbox">
+            <label>
+              <input
+                checked={undefined}
+                onChange={[Function]}
+                type="checkbox" />
+               
+              Times are exact
+            </label>
+          </div>
         </div>
         <div>
           <div

--- a/lib/components/modification/__tests__/__snapshots__/editor.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/editor.js.snap
@@ -252,6 +252,17 @@ exports[`Component > Modification > ModificationEditor renders correctly 1`] = `
                     type="time"
                     value="16:00" />
                 </div>
+                <div
+                  className="checkbox">
+                  <label>
+                    <input
+                      checked={undefined}
+                      onChange={[Function]}
+                      type="checkbox" />
+                     
+                    Times are exact
+                  </label>
+                </div>
               </div>
               <div>
                 <div

--- a/lib/components/modification/__tests__/__snapshots__/frequency-entry.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/frequency-entry.js.snap
@@ -255,6 +255,17 @@ exports[`Component > FrequencyEntry renders correctly 1`] = `
           type="time"
           value="16:00" />
       </div>
+      <div
+        className="checkbox">
+        <label>
+          <input
+            checked={undefined}
+            onChange={[Function]}
+            type="checkbox" />
+           
+          Times are exact
+        </label>
+      </div>
     </div>
     <a
       className="btn btn-danger btn-block"

--- a/lib/components/modification/__tests__/__snapshots__/timetable-entry.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/timetable-entry.js.snap
@@ -127,5 +127,16 @@ exports[`Component > TimetableEntry renders correctly 1`] = `
       type="time"
       value="16:00" />
   </div>
+  <div
+    className="checkbox">
+    <label>
+      <input
+        checked={undefined}
+        onChange={[Function]}
+        type="checkbox" />
+       
+      Times are exact
+    </label>
+  </div>
 </div>
 `;

--- a/lib/components/modification/__tests__/__snapshots__/timetable.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/timetable.js.snap
@@ -156,6 +156,17 @@ exports[`Component > Timetable renders correctly 1`] = `
           type="time"
           value="16:00" />
       </div>
+      <div
+        className="checkbox">
+        <label>
+          <input
+            checked={undefined}
+            onChange={[Function]}
+            type="checkbox" />
+           
+          Times are exact
+        </label>
+      </div>
     </div>
     <div>
       <div

--- a/lib/components/modification/editor.js
+++ b/lib/components/modification/editor.js
@@ -38,24 +38,36 @@ export default class ModificationEditor extends Component {
   constructor (props) {
     super(props)
 
-    const stops = getStops(this.props.modification.segments)
+    if (this.props.modification.segments != null) {
+      const stops = getStops(this.props.modification.segments)
 
-    this.state = {
-      stops,
-      segmentDistances: stops.length > 1
-        ? this.props.modification.segments.map((s) => lineDistance(s.geometry, 'kilometers'))
-        : []
+      this.state = {
+        stops,
+        segmentDistances: stops.length > 1
+          ? this.props.modification.segments.map((s) => lineDistance(s.geometry, 'kilometers'))
+          : []
+      }
+    } else {
+      this.state = {} // just so it's not undefined
     }
   }
 
   componentWillReceiveProps ({modification}) {
     const {segments} = modification
-    if (segments !== this.props.modification.segments) {
-      const stops = getStops(segments)
+    if (segments != null) {
+      if (segments !== this.props.modification.segments) {
+        const stops = getStops(segments)
+        this.setState({
+          ...this.state,
+          stops,
+          segmentDistances: stops.length > 1 ? segments.map((s) => lineDistance(s.geometry, 'kilometers')) : []
+        })
+      }
+    } else {
       this.setState({
         ...this.state,
-        stops,
-        segmentDistances: stops.length > 1 ? segments.map((s) => lineDistance(s.geometry, 'kilometers')) : []
+        stops: undefined,
+        segmentDistances: undefined
       })
     }
   }

--- a/lib/components/modification/timetable-entry.js
+++ b/lib/components/modification/timetable-entry.js
@@ -49,6 +49,9 @@ export default class TimetableEntry extends Component {
     })
   }
 
+  /** Set whether this modification uses exact times */
+  setExactTimes = (e) => this.props.update({ exactTimes: e.target.checked })
+
   render () {
     const {timetable} = this.props
 
@@ -74,6 +77,10 @@ export default class TimetableEntry extends Component {
           onChange={this.setEndTime}
           value={timetable.endTime}
           />
+        <Checkbox
+          label='Times are exact'
+          checked={timetable.exactTimes}
+          onChange={this.setExactTimes} />
       </div>
     )
   }

--- a/lib/utils/__tests__/timetable.js
+++ b/lib/utils/__tests__/timetable.js
@@ -1,0 +1,25 @@
+/* global describe, it, expect */
+
+import {getExactTimesFirstDepartures} from '../timetable'
+import {hhMmStringToSeconds} from '../time'
+
+describe('Utilities > Timetable', () => {
+  it('should generate firstDepartures array correctly', () => {
+    expect(getExactTimesFirstDepartures({
+      startTime: hhMmStringToSeconds('7:00'),
+      endTime: hhMmStringToSeconds('9:00'),
+      headwaySecs: hhMmStringToSeconds('0:15')
+    })).toEqual([
+      '7:00',
+      '7:15',
+      '7:30',
+      '7:45',
+      '8:00',
+      '8:15',
+      '8:30',
+      '8:45'
+      // no 9:00, range is inclusive on left and exclusive on right to match GTFS, per
+      // https://groups.google.com/forum/#!topic/gtfs-changes/5u8yXBrpK2w
+    ].map(hhMmStringToSeconds))
+  })
+})

--- a/lib/utils/convert-to-r5-modification/add-trip-pattern.js
+++ b/lib/utils/convert-to-r5-modification/add-trip-pattern.js
@@ -2,6 +2,7 @@
 
 import getStops from '../get-stops'
 import getHopTimes from '../get-hop-times'
+import {getExactTimesFirstDepartures} from '../timetable'
 
 export default function convertAddTripPattern ({
   bidirectional,
@@ -24,8 +25,14 @@ export default function convertAddTripPattern ({
   const frequencies = timetables.map((tt) => {
     const dwellTimes = stops.map((stop) => tt.dwellTime)
     const hopTimes = getHopTimes(segmentStops, tt.segmentSpeeds)
-    const { monday, tuesday, wednesday, thursday, friday, saturday, sunday, startTime, endTime, headwaySecs } = tt
-    return { monday, tuesday, wednesday, thursday, friday, saturday, sunday, hopTimes, dwellTimes, startTime, endTime, headwaySecs }
+    const { monday, tuesday, wednesday, thursday, friday, saturday, sunday, startTime, endTime, headwaySecs, exactTimes } = tt
+    if (exactTimes) {
+      const firstDepartures = getExactTimesFirstDepartures(tt)
+      return { monday, tuesday, wednesday, thursday, friday, saturday, sunday, hopTimes, dwellTimes, firstDepartures }
+    } else {
+      // pass headway through unaltered
+      return { monday, tuesday, wednesday, thursday, friday, saturday, sunday, hopTimes, dwellTimes, startTime, endTime, headwaySecs }
+    }
   })
 
   return {

--- a/lib/utils/convert-to-r5-modification/convert-to-frequency.js
+++ b/lib/utils/convert-to-r5-modification/convert-to-frequency.js
@@ -1,4 +1,5 @@
 /** export a convert-to-frequency modification to r5 */
+import {getExactTimesFirstDepartures} from '../timetable'
 
 export default function convertConvertToFrequency (mod) {
   let out = {}
@@ -8,10 +9,44 @@ export default function convertConvertToFrequency (mod) {
 
   out.retainTripsOutsideFrequencyEntries = mod.retainTripsOutsideFrequencyEntries
 
-  out.entries = mod.entries.map((entry) => {
-    let outEntry = Object.assign({}, entry, { sourceTrip: `${mod.feed}:${entry.sourceTrip}` })
-    delete outEntry.patternTrips // not needed
-    return outEntry
+  out.entries = mod.entries.map(({
+    monday,
+    tuesday,
+    wednesday,
+    thursday,
+    friday,
+    saturday,
+    sunday,
+    name,
+    sourceTrip,
+    startTime,
+    endTime,
+    headwaySecs,
+    exactTimes
+  }) => {
+    let schedule
+
+    // if exactTimes is true, generate scheduled trips
+    if (exactTimes) {
+      schedule = {
+        firstDepartures: getExactTimesFirstDepartures({ headwaySecs, startTime, endTime })
+      }
+    } else {
+      schedule = { headwaySecs, startTime, endTime }
+    }
+
+    return {
+      monday,
+      tuesday,
+      wednesday,
+      thursday,
+      friday,
+      saturday,
+      sunday,
+      name,
+      sourceTrip,
+      ...schedule
+    }
   })
 
   return out

--- a/lib/utils/time.js
+++ b/lib/utils/time.js
@@ -8,3 +8,8 @@ export function secondsToHhMmString (secs) {
   const remainderMins = mins % 60
   return `${hrs < 10 ? '0' + hrs : hrs}:${remainderMins < 10 ? '0' + remainderMins : remainderMins}`
 }
+
+export function hhMmStringToSeconds (hhmm) {
+  const split = hhmm.split(':')
+  return parseInt(split[0]) * 3600 + parseInt(split[1]) * 60
+}

--- a/lib/utils/timetable.js
+++ b/lib/utils/timetable.js
@@ -6,6 +6,7 @@ export function create (segmentSpeeds = []) {
     dwellTime: 0,
     segmentSpeeds,
     headwaySecs: 600,
+    exactTimes: false,
 
     // active every day
     monday: true,
@@ -18,4 +19,14 @@ export function create (segmentSpeeds = []) {
   }
 
   return timetable
+}
+
+/** Get the first departures for a given timetable that is represented as exact times */
+export function getExactTimesFirstDepartures ({ headwaySecs, startTime, endTime }) {
+  const firstDepartures = [startTime]
+  let departure = startTime
+  // note that interval is [startTime, endTime), to match GTFS
+  // https://groups.google.com/forum/#!topic/gtfs-changes/5u8yXBrpK2w
+  while ((departure += headwaySecs) < endTime) firstDepartures.push(departure)
+  return firstDepartures
 }


### PR DESCRIPTION
Add ability to create routes that have exact times (i.e. they depart at exactly the given frequency from startTime inclusive to endTime exclusive, with no variation/Monte Carlo simulation). Should be ready to go.