### PR TITLE
fix(browsochrones): Don't refetch origin when changing isochrone cutoff.

### DIFF
--- a/lib/utils/browsochrones.js
+++ b/lib/utils/browsochrones.js
@@ -5,6 +5,7 @@ import {crc32} from 'crc'
 import dbg from 'debug'
 import uuid from 'uuid'
 import isEqual from 'lodash.isequal'
+import omit from 'lodash.omit'
 
 import convertToR5Modification from './convert-to-r5-modification'
 import authenticatedFetch from './authenticated-fetch'
@@ -184,6 +185,8 @@ async function ensureOriginLoadedForInstance ({
     }, true).then(res => res.arrayBuffer())
 
     await instance.browsochrones.setOrigin(origin, { x, y })
+    // overwrite things like the date so that they are equal when changing cutoff
+    instance.staticSiteRequest.request = profileRequest
     const { spectrogramData } = await instance.browsochrones.generateSurface(indicator, 'AVERAGE')
     instance.origin = { x, y }
     instance.indicator = indicator


### PR DESCRIPTION
Previously we did not keep the cached profile request up to date as parameters changed, which meant

that, once any parameter that caused refetch had been changed, we were always refetching the origin

if any parameters changed, even if they were parameters that should not cause a refetch. e.g. you

could change the date and that would correctly cause a refetch, but after that changing the

isochrone cutoff would cause a refetch, which it shouldn't.