### PR TITLE
feat(modification-group): Use modification name from messages.

### DIFF
--- a/lib/components/modification/group.js
+++ b/lib/components/modification/group.js
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react'
-import toSentenceCase from 'to-sentence-case'
 
+import messages from '../../utils/messages'
 import DeepEqual from '../deep-equal'
 import Icon from '../icon'
 import ModificationTitle from './title'
@@ -52,7 +52,7 @@ export default class ModificationGroup extends DeepEqual {
           title={`${showOrHide} modification group`}
           >
           <Icon type={iconName} />
-          <span> {toSentenceCase(type)}</span>
+          <span> {messages.modificationType[type]}</span>
           <a
             className='pull-right'
             onClick={this.create}


### PR DESCRIPTION
We have nicely formatted modification names in messages, this uses them rather than sentence-casing the type param. This also allows us to give more human readable names to the less obvious modification types (e.g. convert-to-frequency becomes adjust frequency).